### PR TITLE
解决ant串口配置不能进入其模式问题

### DIFF
--- a/system/src/system_config.cpp
+++ b/system/src/system_config.cpp
@@ -1177,9 +1177,7 @@ int system_config_process(void)
             result = DeviceSetupUsbSerial.process();
 #endif
 #ifdef configSETUP_USARTSERIAL_ENABLE
-            if(result) {
-                result = DeviceSetupUsartSerial.process();
-            }
+            result = DeviceSetupUsartSerial.process();
 #endif
             break;
 #ifdef configSETUP_UDP_ENABLE


### PR DESCRIPTION
1.ant用串口配置不能进入其配置模式
2.去掉system_config.cpp 1180行 if(result)的判断
---

Doneness(完成点):
- [ ] Problem and Solution clearly stated (问题和解决方案描述清楚)
- [ ] Code peer reviewed(代码检查完毕)
- [ ] API tests compiled(API接口测试完毕)
- [ ] Add documentation(添加相关文档)
- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)(合并后往CHANGELOG.md添加注释，包括文档链接和issues)
