### PR TITLE
fixes/esp8266

### DIFF
--- a/bootloader/ant/src/params_impl.h
+++ b/bootloader/ant/src/params_impl.h
@@ -16,7 +16,7 @@
 
 
 //参数区大小不能变动
-typedef struct __attribute__((packed))
+typedef struct
 {
     uint32_t header;          // 系统标志参数区标志  固定为0x5AA5F66F
     uint32_t boot_version;    // bootloader版本号
@@ -27,7 +27,7 @@ typedef struct __attribute__((packed))
 }hal_boot_params_t;
 
 
-typedef struct __attribute__((packed))
+typedef struct
 {
     uint32_t header;               // 系统标志参数区标志  固定为0x5AA5F66F
     char     fwlib_ver[24];        // 固件库版本号

--- a/bootloader/fig/src/params_impl.h
+++ b/bootloader/fig/src/params_impl.h
@@ -16,7 +16,7 @@
 
 
 //参数区大小不能变动
-typedef struct __attribute__((packed))
+typedef struct
 {
     uint32_t header;          // 系统标志参数区标志  固定为0x5AA5F66F
     uint32_t boot_version;    // bootloader版本号
@@ -31,7 +31,7 @@ typedef struct __attribute__((packed))
 }hal_boot_params_t;
 
 
-typedef struct __attribute__((packed))
+typedef struct
 {
     uint32_t header;          // 系统标志参数区标志  固定为0x5AA5F66F
     char     fwlib_ver[24];        // 固件库版本号

--- a/bootloader/fox/src/params_impl.h
+++ b/bootloader/fox/src/params_impl.h
@@ -10,7 +10,7 @@
 
 
 //参数区大小不能变动
-typedef struct __attribute__((packed))
+typedef struct
 {
     uint32_t header;          // 系统标志参数区标志  固定为0x5AA5F66F
     uint32_t boot_version;    // bootloader版本号
@@ -25,7 +25,7 @@ typedef struct __attribute__((packed))
 }hal_boot_params_t;
 
 
-typedef struct __attribute__((packed))
+typedef struct
 {
     uint32_t header;          // 系统标志参数区标志  固定为0x5AA5F66F
     char     fwlib_ver[24];        // 固件库版本号

--- a/bootloader/gl2000/src/params_impl.h
+++ b/bootloader/gl2000/src/params_impl.h
@@ -16,7 +16,7 @@
 
 
 //参数区大小不能变动
-typedef struct __attribute__((packed))
+typedef struct
 {
     uint32_t header;          // 系统标志参数区标志  固定为0x5AA5F66F
     uint32_t boot_version;    // bootloader版本号
@@ -27,7 +27,7 @@ typedef struct __attribute__((packed))
 } hal_boot_params_t;
 
 
-typedef struct __attribute__((packed))
+typedef struct
 {
     uint32_t header;          // 系统标志参数区标志  固定为0x5AA5F66F
     char     fwlib_ver[24];        // 固件库版本号

--- a/bootloader/l6/src/params_impl.h
+++ b/bootloader/l6/src/params_impl.h
@@ -16,7 +16,7 @@
 
 
 //参数区大小不能变动
-typedef struct __attribute__((packed))
+typedef struct
 {
     uint32_t header;          // 系统标志参数区标志  固定为0x5AA5F66F
     uint32_t boot_version;    // bootloader版本号
@@ -27,7 +27,7 @@ typedef struct __attribute__((packed))
 }hal_boot_params_t;
 
 
-typedef struct __attribute__((packed))
+typedef struct
 {
     uint32_t header;               // 系统标志参数区标志  固定为0x5AA5F66F
     char     fwlib_ver[24];        // 固件库版本号

--- a/bootloader/neutron/src/params_impl.h
+++ b/bootloader/neutron/src/params_impl.h
@@ -16,7 +16,7 @@
 
 
 //参数区大小不能变动
-typedef struct __attribute__((packed))
+typedef struct
 {
     uint32_t header;          // 系统标志参数区标志  固定为0x5AA5F66F
     uint32_t boot_version;    // bootloader版本号
@@ -27,7 +27,7 @@ typedef struct __attribute__((packed))
 }hal_boot_params_t;
 
 
-typedef struct __attribute__((packed))
+typedef struct
 {
     uint32_t header;          // 系统标志参数区标志  固定为0x5AA5F66F
     char     fwlib_ver[24];        // 固件库版本号

--- a/bootloader/nut/src/params_impl.h
+++ b/bootloader/nut/src/params_impl.h
@@ -16,7 +16,7 @@
 
 
 //参数区大小不能变动
-typedef struct __attribute__((packed))
+typedef struct
 {
     uint32_t header;          // 系统标志参数区标志  固定为0x5AA5F66F
     uint32_t boot_version;    // bootloader版本号
@@ -31,7 +31,7 @@ typedef struct __attribute__((packed))
 }hal_boot_params_t;
 
 
-typedef struct __attribute__((packed))
+typedef struct
 {
     uint32_t header;          // 系统标志参数区标志  固定为0x5AA5F66F
     char     fwlib_ver[24];        // 固件库版本号

--- a/bootloader/w323/src/params_impl.h
+++ b/bootloader/w323/src/params_impl.h
@@ -16,7 +16,7 @@
 
 
 //参数区大小不能变动
-typedef struct __attribute__((packed))
+typedef struct
 {
     uint32_t header;          // 系统标志参数区标志  固定为0x5AA5F66F
     uint32_t boot_version;    // bootloader版本号
@@ -31,7 +31,7 @@ typedef struct __attribute__((packed))
 } hal_boot_params_t;
 
 
-typedef struct __attribute__((packed))
+typedef struct
 {
     uint32_t header;          // 系统标志参数区标志  固定为0x5AA5F66F
     char     fwlib_ver[24];        // 固件库版本号

--- a/bootloader/w67/src/params_impl.h
+++ b/bootloader/w67/src/params_impl.h
@@ -16,7 +16,7 @@
 
 
 //参数区大小不能变动
-typedef struct __attribute__((packed))
+typedef struct
 {
     uint32_t header;          // 系统标志参数区标志  固定为0x5AA5F66F
     uint32_t boot_version;    // bootloader版本号
@@ -31,7 +31,7 @@ typedef struct __attribute__((packed))
 }hal_boot_params_t;
 
 
-typedef struct __attribute__((packed))
+typedef struct
 {
     uint32_t header;          // 系统标志参数区标志  固定为0x5AA5F66F
     char     fwlib_ver[24];        // 固件库版本号

--- a/build/linker/esp8266/nut/linker_nut_app.ld
+++ b/build/linker/esp8266/nut/linker_nut_app.ld
@@ -161,12 +161,10 @@ SECTIONS
     _irom0_text_start = ABSOLUTE(.);
     *(.subsys.version.header)
     *(.subsys.version)
-    /*
     *.c.o( EXCLUDE_FILE (umm_malloc.c.o) .literal*, \
            EXCLUDE_FILE (umm_malloc.c.o) .text*)
     *.cpp.o(.literal*, .text*)
     *.ino.o(.literal*, .text*)
-    */
     *libc.a:(.literal .text .literal.* .text.*)
     *libm.a:(.literal .text .literal.* .text.*)
     *libgcc.a:_umoddi3.o(.literal .text)
@@ -176,16 +174,6 @@ SECTIONS
     *liblwip_gcc.a:(.literal .text .literal.* .text.*)
     *liblwip_src.a:(.literal .text .literal.* .text.*)
     *libaxtls.a:(.literal .text .literal.* .text.*)
-    *libuser.a:(.literal .text .literal.* .text.*)
-    *libhal.a:( EXCLUDE_FILE (umm_malloc.c.o) .literal, \
-                EXCLUDE_FILE (umm_malloc.c.o) .text, \
-                EXCLUDE_FILE (umm_malloc.c.o) .literal*, \
-                EXCLUDE_FILE (umm_malloc.c.o) .text*)
-    *libplatform.a:(.literal .text .literal.* .text.*)
-    *libservices.a:(.literal .text .literal.* .text.*)
-    *libsystem.a:(.literal .text .literal.* .text.*)
-    *libwiring.a:(.literal .text .literal.* .text.*)
-    *libwiring_ex.a:(.literal .text .literal.* .text.*)
     *(.irom0.literal .irom.literal .irom.text.literal .irom0.text .irom.text .irom.text.*)
     _irom0_text_end = ABSOLUTE(.);
     _flash_code_end = ABSOLUTE(.);
@@ -223,18 +211,9 @@ SECTIONS
     *(.init.literal)
     *(.init)
     *(.literal .text .literal.* .text.* .stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.*)
-    /*
-    *.cpp.o(.iram.text)
     *.c.o(.iram.text)
+    *.cpp.o(.iram.text)
     *.ino.o(.iram.text)
-    */
-    *libuser.a:(.iram.text)
-    *libhal.a:(.iram.text)
-    *libplatform.a:(.iram.text)
-    *libservices.a:(.iram.text)
-    *libsystem.a:(.iram.text)
-    *libwiring.a:(.iram.text)
-    *libwiring_ex.a:(.iram.text)
     *(.fini.literal)
     *(.fini)
     *(.gnu.version)

--- a/build/linker/esp8266/w67/linker_w67_app.ld
+++ b/build/linker/esp8266/w67/linker_w67_app.ld
@@ -161,12 +161,10 @@ SECTIONS
     _irom0_text_start = ABSOLUTE(.);
     *(.subsys.version.header)
     *(.subsys.version)
-    /*
     *.c.o( EXCLUDE_FILE (umm_malloc.c.o) .literal*, \
            EXCLUDE_FILE (umm_malloc.c.o) .text*)
     *.cpp.o(.literal*, .text*)
     *.ino.o(.literal*, .text*)
-    */
     *libc.a:(.literal .text .literal.* .text.*)
     *libm.a:(.literal .text .literal.* .text.*)
     *libgcc.a:_umoddi3.o(.literal .text)
@@ -176,16 +174,6 @@ SECTIONS
     *liblwip_gcc.a:(.literal .text .literal.* .text.*)
     *liblwip_src.a:(.literal .text .literal.* .text.*)
     *libaxtls.a:(.literal .text .literal.* .text.*)
-    *libuser.a:(.literal .text .literal.* .text.*)
-    *libhal.a:( EXCLUDE_FILE (umm_malloc.c.o) .literal, \
-                EXCLUDE_FILE (umm_malloc.c.o) .text, \
-                EXCLUDE_FILE (umm_malloc.c.o) .literal*, \
-                EXCLUDE_FILE (umm_malloc.c.o) .text*)
-    *libplatform.a:(.literal .text .literal.* .text.*)
-    *libservices.a:(.literal .text .literal.* .text.*)
-    *libsystem.a:(.literal .text .literal.* .text.*)
-    *libwiring.a:(.literal .text .literal.* .text.*)
-    *libwiring_ex.a:(.literal .text .literal.* .text.*)
     *(.irom0.literal .irom.literal .irom.text.literal .irom0.text .irom.text .irom.text.*)
     _irom0_text_end = ABSOLUTE(.);
     _flash_code_end = ABSOLUTE(.);
@@ -223,18 +211,9 @@ SECTIONS
     *(.init.literal)
     *(.init)
     *(.literal .text .literal.* .text.* .stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.*)
-    /*
-    *.cpp.o(.iram.text)
     *.c.o(.iram.text)
+    *.cpp.o(.iram.text)
     *.ino.o(.iram.text)
-    */
-    *libuser.a:(.iram.text)
-    *libhal.a:(.iram.text)
-    *libplatform.a:(.iram.text)
-    *libservices.a:(.iram.text)
-    *libsystem.a:(.iram.text)
-    *libwiring.a:(.iram.text)
-    *libwiring_ex.a:(.iram.text)
     *(.fini.literal)
     *(.fini)
     *(.gnu.version)

--- a/hal/inc/inet_hal.h
+++ b/hal/inc/inet_hal.h
@@ -29,13 +29,21 @@ extern "C" {
 #include "static_assert.h"
 
 /** 255.255.255.255 */
+#ifndef IPADDR_NONE
 #define IPADDR_NONE         ((uint32_t)0xffffffffUL)
+#endif
 /** 127.0.0.1 */
+#ifndef IPADDR_LOOPBACK
 #define IPADDR_LOOPBACK     ((uint32_t)0x7f000001UL)
+#endif
 /** 0.0.0.0 */
+#ifndef IPADDR_ANY
 #define IPADDR_ANY          ((uint32_t)0x00000000UL)
+#endif
 /** 255.255.255.255 */
+#ifndef IPADDR_BROADCAST
 #define IPADDR_BROADCAST    ((uint32_t)0xffffffffUL)
+#endif
 
 #define HAL_IPv6 0
 

--- a/hal/src/ant/params_impl.h
+++ b/hal/src/ant/params_impl.h
@@ -28,7 +28,7 @@
 
 
 //参数区大小不能变动
-typedef struct __attribute__((packed))
+typedef struct
 {
     uint32_t header;          // 系统标志参数区标志  固定为0x5AA5F66F
     uint32_t boot_version;    // bootloader版本号
@@ -39,7 +39,7 @@ typedef struct __attribute__((packed))
 }hal_boot_params_t;
 
 
-typedef struct __attribute__((packed))
+typedef struct
 {
     uint32_t header;               // 系统标志参数区标志  固定为0x5AA5F66F
     char     fwlib_ver[24];        // 固件库版本号

--- a/hal/src/anytest/params_impl.h
+++ b/hal/src/anytest/params_impl.h
@@ -28,7 +28,7 @@
 
 
 //参数区大小不能变动
-typedef struct __attribute__((packed))
+typedef struct
 {
     uint32_t header;          // 系统标志参数区标志  固定为0x5AA5F66F
     uint32_t boot_version;    // bootloader版本号
@@ -39,7 +39,7 @@ typedef struct __attribute__((packed))
 }hal_boot_params_t;
 
 
-typedef struct __attribute__((packed))
+typedef struct
 {
     uint32_t header;          // 系统标志参数区标志  固定为0x5AA5F66F
     char     fwlib_ver[24];        // 固件库版本号

--- a/hal/src/atom/params_impl.h
+++ b/hal/src/atom/params_impl.h
@@ -28,7 +28,7 @@
 
 
 //参数区大小不能变动
-typedef struct __attribute__((packed))
+typedef struct
 {
     uint32_t header;          // 系统标志参数区标志  固定为0x5AA5F66F
     uint32_t boot_version;    // bootloader版本号
@@ -39,7 +39,7 @@ typedef struct __attribute__((packed))
 }hal_boot_params_t;
 
 
-typedef struct __attribute__((packed))
+typedef struct
 {
     uint32_t header;          // 系统标志参数区标志  固定为0x5AA5F66F
     char     fwlib_ver[24];        // 固件库版本号

--- a/hal/src/atom/socket/enums_hal.h
+++ b/hal/src/atom/socket/enums_hal.h
@@ -39,8 +39,9 @@ typedef uint32_t MDM_IP;
                         (((uint32_t)(b))<<16) | \
                         (((uint32_t)(c))<< 8) | \
                         (((uint32_t)(d))<< 0))
-
+#ifndef MACSTR
 #define MACSTR           "%x:%x:%x:%x:%x:%x"
+#endif
 
 // ----------------------------------------------------------------
 // Sockets

--- a/hal/src/esp32-share/delay_hal.c
+++ b/hal/src/esp32-share/delay_hal.c
@@ -25,6 +25,7 @@
 
 #include "hw_config.h"
 #include "delay_hal.h"
+#include "timer_hal.h"
 //#include "watchdog_hal.h"
 #include "sdkconfig.h"
 #include "freertos/FreeRTOS.h"

--- a/hal/src/esp32-share/eeprom_hal.c
+++ b/hal/src/esp32-share/eeprom_hal.c
@@ -56,10 +56,10 @@ void HAL_EEPROM_Init(void)
 uint8_t HAL_EEPROM_Read(uint32_t address)
 {
     if (address < 0 || (size_t)address >= size) {
-        return;
+        return 0xFF;
     }
     if (!eeprom_mem) {
-        return;
+        return 0xFF;
     }
     return eeprom_mem[address];
 }

--- a/hal/src/esp32-share/esp32/esp32-hal-adc.h
+++ b/hal/src/esp32-share/esp32/esp32-hal-adc.h
@@ -40,21 +40,21 @@ typedef enum {
  *
  * Note: compatibility with Arduino SAM
  */
-void _analogReadResolution(uint8_t bits);
+void __analogReadResolution(uint8_t bits);
 
 /*
  * Sets the sample bits and read resolution
  * Default is 12bit (0 - 4095)
  * Range is 9 - 12
  * */
-void _analogSetWidth(uint8_t bits);
+void __analogSetWidth(uint8_t bits);
 
 /*
  * Set number of cycles per sample
  * Default is 8 and seems to do well
  * Range is 1 - 255
  * */
-void _analogSetCycles(uint8_t cycles);
+void __analogSetCycles(uint8_t cycles);
 
 /*
  * Set number of samples in the range.
@@ -65,32 +65,32 @@ void _analogSetCycles(uint8_t cycles);
  * like the sensitivity has been multiplied
  * that many times
  * */
-void _analogSetSamples(uint8_t samples);
+void __analogSetSamples(uint8_t samples);
 
 /*
  * Set the divider for the ADC clock.
  * Default is 1
  * Range is 1 - 255
  * */
-void _analogSetClockDiv(uint8_t clockDiv);
+void __analogSetClockDiv(uint8_t clockDiv);
 
 /*
  * Set the attenuation for all channels
  * Default is 11db
  * */
-void _analogSetAttenuation(adc_attenuation_t attenuation);
+void __analogSetAttenuation(adc_attenuation_t attenuation);
 
 /*
  * Set the attenuation for particular pin
  * Default is 11db
  * */
-void _analogSetPinAttenuation(uint8_t pin, adc_attenuation_t attenuation);
+void __analogSetPinAttenuation(uint8_t pin, adc_attenuation_t attenuation);
 
 /*
  * Get value for HALL sensor (without LNA)
  * connected to pins 36(SVP) and 39(SVN)
  * */
-int _hallRead();
+int __hallRead();
 
 /*
  * Non-Blocking API (almost)
@@ -104,22 +104,22 @@ int _hallRead();
 /*
  * Attach pin to ADC (will also clear any other analog mode that could be on)
  * */
-bool _adcAttachPin(uint8_t pin);
+bool __adcAttachPin(uint8_t pin);
 
 /*
  * Start ADC conversion on attached pin's bus
  * */
-bool _adcStart(uint8_t pin);
+bool __adcStart(uint8_t pin);
 
 /*
  * Check if conversion on the pin's ADC bus is currently running
  * */
-bool _adcBusy(uint8_t pin);
+bool __adcBusy(uint8_t pin);
 
 /*
  * Get the result of the conversion (will wait if it have not finished)
  * */
-uint16_t _adcEnd(uint8_t pin);
+uint16_t __adcEnd(uint8_t pin);
 
 #ifdef __cplusplus
 }

--- a/hal/src/esp32-share/socket_hal.cpp
+++ b/hal/src/esp32-share/socket_hal.cpp
@@ -16,11 +16,11 @@ License along with this library; if not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 
 #include <string.h>
-#include "socket_hal.h"
 extern "C" {
 #include <lwip/sockets.h>
 #include <lwip/netdb.h>
 }
+#include "socket_hal.h"
 //#define HAL_SOCKET_DEBUG
 
 #ifdef HAL_SOCKET_DEBUG

--- a/hal/src/esp32-share/usart_hal.c
+++ b/hal/src/esp32-share/usart_hal.c
@@ -187,7 +187,7 @@ uint32_t HAL_USART_Write_Data(HAL_USART_Serial serial, uint8_t data)
 
 uint32_t HAL_USART_Write_NineBitData(HAL_USART_Serial serial, uint16_t data)
 {
-    uartWriteBuf(usartMap[serial]->usart, (uint8_t *)data, 2);
+    uartWriteBuf(usartMap[serial]->usart, (uint8_t *)&data, 2);
     return 1;
 }
 

--- a/hal/src/esp32-share/wlan_hal.cpp
+++ b/hal/src/esp32-share/wlan_hal.cpp
@@ -23,11 +23,11 @@
 #include "flash_map.h"
 #include "delay_hal.h"
 #include "macaddr_hal.h"
-#include "inet_hal.h"
 
 #include "esp32-hal-wifi.h"
 #include "esp_wifi.h"
 #include "lwip/dns.h"
+#include "inet_hal.h"
 
 
 #define STATION_IF      0x00

--- a/hal/src/esp8266-share/eeprom_hal.c
+++ b/hal/src/esp8266-share/eeprom_hal.c
@@ -57,10 +57,10 @@ void HAL_EEPROM_Init(void)
 uint8_t HAL_EEPROM_Read(uint32_t address)
 {
     if (address < 0 || (size_t)address >= size) {
-        return;
+        return 0xFF;
     }
     if (!eeprom_mem) {
-        return;
+        return 0xFF;
     }
     return eeprom_mem[address];
 }

--- a/hal/src/esp8266-share/esp8266/esp8266-hal-servotimers.c
+++ b/hal/src/esp8266-share/esp8266/esp8266-hal-servotimers.c
@@ -29,6 +29,7 @@
 volatile uint32_t _cycleStartTimer0;
 volatile int8_t _currentChannelTimer0;
 
+void ESP8266setEndOfCycleTimer0();
 
 void ESP8266ServoTimer0(void)
 {
@@ -134,6 +135,8 @@ servo_timer_t  s_servoTimer0 = {
 
 volatile uint32_t _cycleTicksTimer1;
 volatile int8_t _currentChannelTimer1;
+
+void ESP8266setEndOfCycleTimer1();
 
 void ESP8266ServoTimer1()
 {

--- a/hal/src/esp8266-share/esp8266/esp8266-hal-spi.h
+++ b/hal/src/esp8266-share/esp8266/esp8266-hal-spi.h
@@ -1,9 +1,9 @@
-/* 
+/*
   SPI.h - SPI library for esp8266
 
   Copyright (c) 2015 Hristo Gochkov. All rights reserved.
   This file is part of the esp8266 core for Arduino environment.
- 
+
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public
   License as published by the Free Software Foundation; either
@@ -47,7 +47,7 @@ bool spi_pins(int8_t sck, int8_t miso, int8_t mosi, int8_t ss);
 void spi_begin(int8_t sck, int8_t miso, int8_t mosi, int8_t ss);
 void spi_end();
 void spi_setHwCs(bool use);
-void spi_setBitOrder(uint8_t bitOrder);  
+void spi_setBitOrder(uint8_t bitOrder);
 void spi_setDataMode(uint8_t dataMode);
 void spi_setFrequency(uint32_t freq);
 void spi_setClockDivider(uint32_t clockDiv);
@@ -65,7 +65,6 @@ void spi_endTransaction(void);
 
 void spi_writeBytes_(uint8_t * data, uint8_t size);
 void spi_transferBytes_(uint8_t * out, uint8_t * in, uint8_t size);
-inline void spi_setDataBits(uint16_t bits);
 
 
 #endif

--- a/hal/src/esp8266-share/esp8266/esp8266-hal-uart.c
+++ b/hal/src/esp8266-share/esp8266/esp8266-hal-uart.c
@@ -35,6 +35,7 @@
  * NC = Not Connected to Module Pads --> No Access
  *
  */
+#include <stdlib.h>
 #include "esp8266_peri.h"
 #include "user_interface.h"
 #include "esp8266-hal-uart.h"

--- a/hal/src/esp8266-share/esp8266/esp8266_downfile.c
+++ b/hal/src/esp8266-share/esp8266/esp8266_downfile.c
@@ -51,6 +51,7 @@ char hostname_tmp[128] = {0};
 char httppara_tmp[128] = {0};
 
 void downfile_rsp(void *arg);
+void downFile(char *hostname, char *httppara, char *md5para, void *check_cb);
 
 void down_default_app_cb(void){
     os_timer_disarm(&downfile_timer);
@@ -159,7 +160,7 @@ down_status_t esp8266_downOnlineApp(const char *host, const char *param, const c
 {
     filetype = ONLINE_APP_FILE;
     down_progress=0;
-    downFile(host, param, md5, downfile_rsp);
+    downFile((char *)host, (char *)param, (char *)md5, downfile_rsp);
     _downOnlineAppFile_status = DOWNSTATUS_DOWNING;
     return _downOnlineAppFile_status;
 }

--- a/hal/src/esp8266-share/socket/enums_hal.h
+++ b/hal/src/esp8266-share/socket/enums_hal.h
@@ -40,7 +40,9 @@ typedef uint32_t MDM_IP;
                         (((uint32_t)(c))<< 8) | \
                         (((uint32_t)(d))<< 0))
 
+#ifndef MACSTR
 #define MACSTR           "%x:%x:%x:%x:%x:%x"
+#endif
 
 // ----------------------------------------------------------------
 // Sockets

--- a/hal/src/esp8266-share/socket_hal.cpp
+++ b/hal/src/esp8266-share/socket_hal.cpp
@@ -15,8 +15,8 @@ You should have received a copy of the GNU Lesser General Public
 License along with this library; if not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 
-#include "socket_hal.h"
 #include "socket/esp8266_conn.h"
+#include "socket_hal.h"
 
 Esp8266ConnClass esp8266_conn;
 

--- a/hal/src/esp8266-share/usart_hal.cpp
+++ b/hal/src/esp8266-share/usart_hal.cpp
@@ -196,7 +196,7 @@ uint32_t HAL_USART_Write_Data(HAL_USART_Serial serial, uint8_t data)
 
 uint32_t HAL_USART_Write_NineBitData(HAL_USART_Serial serial, uint16_t data)
 {
-    uartWriteBuf(usartMap[serial]->usart, (uint8_t *)data, 2);
+    uartWriteBuf(usartMap[serial]->usart, (uint8_t *)&data, 2);
     return 1;
 }
 

--- a/hal/src/fig/flash_map.h
+++ b/hal/src/fig/flash_map.h
@@ -20,7 +20,9 @@
 #ifndef FLASH_MAP_H_
 #define FLASH_MAP_H_
 
+#ifndef SPI_FLASH_SEC_SIZE
 #define SPI_FLASH_SEC_SIZE      0x1000     //Flash 扇区大小
+#endif
 #define LIMIT_ERASE_SIZE        0x10000    //Flash 擦除扇区大小限制
 
 /*

--- a/hal/src/fig/ota_flash_hal.cpp
+++ b/hal/src/fig/ota_flash_hal.cpp
@@ -19,8 +19,8 @@
 
 #include "ota_flash_hal.h"
 #include "core_hal.h"
-#include "flash_map.h"
 #include "flash_mal.h"
+#include "flash_map.h"
 #include "params_hal.h"
 #include "ui_hal.h"
 
@@ -234,6 +234,6 @@ int HAL_FLASH_Update(const uint8_t *pBuffer, uint32_t address, uint32_t length, 
 
 hal_update_complete_t HAL_FLASH_End(void)
 {
-    return 0;
+    return HAL_UPDATE_ERROR;
 }
 

--- a/hal/src/fig/params_impl.h
+++ b/hal/src/fig/params_impl.h
@@ -28,7 +28,7 @@
 
 
 //参数区大小不能变动
-typedef struct __attribute__((packed))
+typedef struct
 {
     uint32_t header;          // 系统标志参数区标志  固定为0x5AA5F66F
     uint32_t boot_version;    // bootloader版本号
@@ -43,7 +43,7 @@ typedef struct __attribute__((packed))
 }hal_boot_params_t;
 
 
-typedef struct __attribute__((packed))
+typedef struct
 {
     uint32_t header;          // 系统标志参数区标志  固定为0x5AA5F66F
     char     fwlib_ver[24];        // 固件库版本号

--- a/hal/src/fig/ui_hal.c
+++ b/hal/src/fig/ui_hal.c
@@ -22,6 +22,7 @@
 #include "soc/gpio_sig_map.h"
 #include "soc/io_mux_reg.h"
 #include "soc/rtc_io_reg.h"
+#include "rom/gpio.h"
 
 
 #define USER_GPIO_PIN          4

--- a/hal/src/fox/params_impl.h
+++ b/hal/src/fox/params_impl.h
@@ -28,7 +28,7 @@
 
 
 //参数区大小不能变动
-typedef struct __attribute__((packed))
+typedef struct
 {
     uint32_t header;          // 系统标志参数区标志  固定为0x5AA5F66F
     uint32_t boot_version;    // bootloader版本号
@@ -43,7 +43,7 @@ typedef struct __attribute__((packed))
 }hal_boot_params_t;
 
 
-typedef struct __attribute__((packed))
+typedef struct
 {
     uint32_t header;          // 系统标志参数区标志  固定为0x5AA5F66F
     char     fwlib_ver[24];        // 固件库版本号

--- a/hal/src/gl2000/params_impl.h
+++ b/hal/src/gl2000/params_impl.h
@@ -28,7 +28,7 @@
 
 
 //参数区大小不能变动
-typedef struct __attribute__((packed))
+typedef struct
 {
     uint32_t header;          // 系统标志参数区标志  固定为0x5AA5F66F
     uint32_t boot_version;    // bootloader版本号
@@ -39,7 +39,7 @@ typedef struct __attribute__((packed))
 }hal_boot_params_t;
 
 
-typedef struct __attribute__((packed))
+typedef struct
 {
     uint32_t header;          // 系统标志参数区标志  固定为0x5AA5F66F
     char     fwlib_ver[24];        // 固件库版本号

--- a/hal/src/l6/params_impl.h
+++ b/hal/src/l6/params_impl.h
@@ -28,7 +28,7 @@
 
 
 //参数区大小不能变动
-typedef struct __attribute__((packed))
+typedef struct
 {
     uint32_t header;          // 系统标志参数区标志  固定为0x5AA5F66F
     uint32_t boot_version;    // bootloader版本号
@@ -39,7 +39,7 @@ typedef struct __attribute__((packed))
 }hal_boot_params_t;
 
 
-typedef struct __attribute__((packed))
+typedef struct
 {
     uint32_t header;               // 系统标志参数区标志  固定为0x5AA5F66F
     char     fwlib_ver[24];        // 固件库版本号

--- a/hal/src/neutron/modem/inc/enums_hal.h
+++ b/hal/src/neutron/modem/inc/enums_hal.h
@@ -91,7 +91,9 @@ typedef uint32_t MDM_IP;
                         (((uint32_t)(c))<< 8) | \
                         (((uint32_t)(d))<< 0))
 
+#ifndef MACSTR
 #define MACSTR           "%x:%x:%x:%x:%x:%x"
+#endif
 
 typedef struct {
     MDM_IP  IpAddr;             // byte 0 is MSB, byte 3 is LSB

--- a/hal/src/neutron/params_impl.h
+++ b/hal/src/neutron/params_impl.h
@@ -28,7 +28,7 @@
 
 
 //参数区大小不能变动
-typedef struct __attribute__((packed))
+typedef struct
 {
     uint32_t header;          // 系统标志参数区标志  固定为0x5AA5F66F
     uint32_t boot_version;    // bootloader版本号
@@ -39,7 +39,7 @@ typedef struct __attribute__((packed))
 }hal_boot_params_t;
 
 
-typedef struct __attribute__((packed))
+typedef struct
 {
     uint32_t header;          // 系统标志参数区标志  固定为0x5AA5F66F
     char     fwlib_ver[24];        // 固件库版本号

--- a/hal/src/nut/flash_map.h
+++ b/hal/src/nut/flash_map.h
@@ -20,8 +20,9 @@
 #ifndef FLASH_MAP_H_
 #define FLASH_MAP_H_
 
-
+#ifndef SPI_FLASH_SEC_SIZE
 #define SPI_FLASH_SEC_SIZE      0x1000       //Flash 扇区大小
+#endif
 #define LIMIT_ERASE_SIZE        0x10000    //Flash 擦除扇区大小限制
 
 

--- a/hal/src/nut/ota_flash_hal.cpp
+++ b/hal/src/nut/ota_flash_hal.cpp
@@ -202,6 +202,6 @@ int HAL_FLASH_Update(const uint8_t *pBuffer, uint32_t address, uint32_t length, 
 
 hal_update_complete_t HAL_FLASH_End(void)
 {
-    return 0;
+    return HAL_UPDATE_ERROR;
 }
 

--- a/hal/src/nut/params_impl.h
+++ b/hal/src/nut/params_impl.h
@@ -28,7 +28,7 @@
 
 
 //参数区大小不能变动
-typedef struct __attribute__((packed))
+typedef struct
 {
     uint32_t header;          // 系统标志参数区标志  固定为0x5AA5F66F
     uint32_t boot_version;    // bootloader版本号
@@ -43,7 +43,7 @@ typedef struct __attribute__((packed))
 }hal_boot_params_t;
 
 
-typedef struct __attribute__((packed))
+typedef struct
 {
     uint32_t header;          // 系统标志参数区标志  固定为0x5AA5F66F
     char     fwlib_ver[24];        // 固件库版本号

--- a/hal/src/nut/ui_hal.c
+++ b/hal/src/nut/ui_hal.c
@@ -70,19 +70,19 @@ uint32_t HAL_UI_Mode_Button_Pressed(void)
 
 int HAL_UI_RGB_Get_Info(rgb_info_t *pinfo)
 {
-    memcpy(pinfo, &rgb_info, sizeof(rgb_info_t));
+    memcpy(pinfo, (uint8_t *)&rgb_info, sizeof(rgb_info_t));
     return 0;
 }
 
 int HAL_UI_RGB_Set_Info(rgb_info_t info)
 {
-    memcpy(&rgb_info, &info, sizeof(rgb_info_t));
+    memcpy((uint8_t *)&rgb_info, &info, sizeof(rgb_info_t));
     return 0;
 }
 
 void HAL_UI_RGB_Color(uint32_t color)
 {
-    memset(&rgb_info, 0, sizeof(rgb_info));
+    memset((uint8_t *)&rgb_info, 0, sizeof(rgb_info));
     rgb_info.rgb_mode = RGB_MODE_COLOR;
     rgb_info.rgb_color = color;
     Set_RGB_Color(color);
@@ -90,7 +90,7 @@ void HAL_UI_RGB_Color(uint32_t color)
 
 void HAL_UI_RGB_Blink(uint32_t color, uint16_t period)
 {
-    memset(&rgb_info, 0, sizeof(rgb_info));
+    memset((uint8_t *)&rgb_info, 0, sizeof(rgb_info));
     rgb_info.rgb_mode = RGB_MODE_BLINK;
     rgb_info.rgb_color = color;
     rgb_info.rgb_period = period>100 ? period >> 1 : 50;

--- a/hal/src/w323/ota_flash_hal.cpp
+++ b/hal/src/w323/ota_flash_hal.cpp
@@ -126,6 +126,6 @@ int HAL_FLASH_Update(const uint8_t *pBuffer, uint32_t address, uint32_t length, 
 
 hal_update_complete_t HAL_FLASH_End(void)
 {
-    return 0;
+    return HAL_UPDATE_ERROR;
 }
 

--- a/hal/src/w323/params_impl.h
+++ b/hal/src/w323/params_impl.h
@@ -28,7 +28,7 @@
 
 
 //参数区大小不能变动
-typedef struct __attribute__((packed))
+typedef struct
 {
     uint32_t header;          // 系统标志参数区标志  固定为0x5AA5F66F
     uint32_t boot_version;    // bootloader版本号
@@ -43,7 +43,7 @@ typedef struct __attribute__((packed))
 }hal_boot_params_t;
 
 
-typedef struct __attribute__((packed))
+typedef struct
 {
     uint32_t header;          // 系统标志参数区标志  固定为0x5AA5F66F
     char     fwlib_ver[24];        // 固件库版本号

--- a/hal/src/w67/ota_flash_hal.cpp
+++ b/hal/src/w67/ota_flash_hal.cpp
@@ -105,6 +105,6 @@ int HAL_FLASH_Update(const uint8_t *pBuffer, uint32_t address, uint32_t length, 
 
 hal_update_complete_t HAL_FLASH_End(void)
 {
-    return 0;
+    return HAL_UPDATE_ERROR;
 }
 

--- a/hal/src/w67/params_impl.h
+++ b/hal/src/w67/params_impl.h
@@ -28,7 +28,7 @@
 
 
 //参数区大小不能变动
-typedef struct __attribute__((packed))
+typedef struct
 {
     uint32_t header;          // 系统标志参数区标志  固定为0x5AA5F66F
     uint32_t boot_version;    // bootloader版本号
@@ -43,7 +43,7 @@ typedef struct __attribute__((packed))
 }hal_boot_params_t;
 
 
-typedef struct __attribute__((packed))
+typedef struct
 {
     uint32_t header;          // 系统标志参数区标志  固定为0x5AA5F66F
     char     fwlib_ver[24];        // 固件库版本号

--- a/platform/MCU/ESP32-Arduino/IntoRobot_Firmware_Driver/inc/hw_config.h
+++ b/platform/MCU/ESP32-Arduino/IntoRobot_Firmware_Driver/inc/hw_config.h
@@ -31,6 +31,7 @@
 /* Includes ------------------------------------------------------------------*/
 #include <stdint.h>
 #include <stdbool.h>
+#include <stdlib.h>
 #include <string.h>
 #include "platform_config.h"
 #include "hw_ticks.h"

--- a/platform/MCU/ESP8266-Arduino/IntoRobot_Firmware_Driver/src/abi.cpp
+++ b/platform/MCU/ESP8266-Arduino/IntoRobot_Firmware_Driver/src/abi.cpp
@@ -49,11 +49,13 @@ extern "C" void __cxa_deleted_virtual(void) __attribute__ ((__noreturn__));
 
 void __cxa_pure_virtual(void)
 {
+    while(1);
     //panic();
 }
 
 void __cxa_deleted_virtual(void)
 {
+    while(1);
     //panic();
 }
 

--- a/services/inc/config.h
+++ b/services/inc/config.h
@@ -31,7 +31,6 @@
 
 // define to include __FILE__ information within the debug output
 #define INCLUDE_FILE_INFO_IN_DEBUG
-#define MAX_DEBUG_MESSAGE_LENGTH        256
 
 #define RESET_ON_CFOD                   1       // 1 Will do reset 0 will not
 #define MAX_SEC_WAIT_CONNECT            8       // Number of second a TCP,  will wait

--- a/services/src/debug.cpp
+++ b/services/src/debug.cpp
@@ -26,6 +26,8 @@
 #include "service_debug.h"
 #include "timer_hal.h"
 
+#define MAX_DEBUG_MESSAGE_LENGTH        256
+
 #undef PLATFORM_THREADING  // 关闭debug 任务保护
 
 #if PLATFORM_THREADING

--- a/services/src/md5_builder.cpp
+++ b/services/src/md5_builder.cpp
@@ -63,7 +63,7 @@ bool MD5Builder::addStream(Stream & stream, const size_t maxLen)
         }
 
         // read data and check if we got something
-        int numBytesRead = stream.readBytes(buf, readBytes);
+        int numBytesRead = stream.readBytes((char *)buf, readBytes);
         if(numBytesRead< 1) {
             return false;
         }

--- a/system/inc/system_cloud.h
+++ b/system/inc/system_cloud.h
@@ -59,8 +59,8 @@ struct CallBackNode
 {
     void (*callback)(uint8_t*, uint32_t);
     uint8_t qos;
-    const char *topic;
-    const char *device_id;
+    char *topic;
+    char *device_id;
     topic_version_t version;
 };
 
@@ -68,8 +68,8 @@ struct WidgetCallBackNode
 {
     WidgetBaseClass *pWidgetBase;
     uint8_t qos;
-    const char *topic;
-    const char *device_id;
+    char *topic;
+    char *device_id;
     topic_version_t version;
 };
 

--- a/system/inc/system_task.h
+++ b/system/inc/system_task.h
@@ -41,7 +41,7 @@ unsigned backoff_period(unsigned connection_attempts);
  */
 void* system_internal(int item, void* reserved);
 
-void system_delay_ms(unsigned long ms, bool force_no_background_loop=false);
+void system_delay_ms(unsigned long ms, bool force_no_background_loop);
 
 #define INTOROBOT_LOOP_DELAY_MILLIS                 1000    //1sec
 

--- a/system/inc/system_update.h
+++ b/system/inc/system_update.h
@@ -4,7 +4,9 @@
 
 #include "intorobot_config.h"
 #include "md5_builder.h"
+#include "wiring_ticks.h"
 #include "wiring_httpclient.h"
+
 
 #ifdef __cplusplus
 extern "C" {

--- a/system/src/system_cloud.cpp
+++ b/system/src/system_cloud.cpp
@@ -79,12 +79,12 @@ MqttClientClass g_mqtt_client;
 RGBLEDState led_state;
 
 
-pCallBack get_subscribe_callback(char * fulltopic);
-WidgetBaseClass *get_widget_subscribe_callback(char * fulltopic);
-void add_subscribe_callback(topic_version_t version, char *topic, char *device_id, void (*callback)(uint8_t*, uint32_t), uint8_t qos);
-void add_widget_subscibe_callback(topic_version_t version, char *topic, char *device_id, WidgetBaseClass *pWidgetBase, uint8_t qos);
-void del_subscribe_callback(topic_version_t version, char * topic, char *device_id);
-void mqtt_receive_debug_info(uint8_t *pIn, uint32_t len);
+static pCallBack get_subscribe_callback(char * fulltopic);
+static WidgetBaseClass *get_widget_subscribe_callback(char * fulltopic);
+static void add_subscribe_callback(topic_version_t version, char *topic, char *device_id, void (*callback)(uint8_t*, uint32_t), uint8_t qos);
+static void add_widget_subscibe_callback(topic_version_t version, char *topic, char *device_id, WidgetBaseClass *pWidgetBase, uint8_t qos);
+static void del_subscribe_callback(topic_version_t version, char * topic, char *device_id);
+static void mqtt_receive_debug_info(uint8_t *pIn, uint32_t len);
 
 void mqtt_client_callback(char *topic, uint8_t *payload, uint32_t length)
 {
@@ -937,13 +937,13 @@ static void add_subscribe_callback(topic_version_t version, char *topic, char *d
         } else {
             g_callback_list.callback_node[g_callback_list.total_callbacks].callback = callback;
             g_callback_list.callback_node[g_callback_list.total_callbacks].qos = qos;
-            g_callback_list.callback_node[g_callback_list.total_callbacks].topic = malloc(strlen(topic)+1);
+            g_callback_list.callback_node[g_callback_list.total_callbacks].topic = (char *)malloc(strlen(topic)+1);
             if(NULL != g_callback_list.callback_node[g_callback_list.total_callbacks].topic) {
                 memset(g_callback_list.callback_node[g_callback_list.total_callbacks].topic, 0, strlen(topic)+1);
                 memcpy(g_callback_list.callback_node[g_callback_list.total_callbacks].topic, topic, strlen(topic));
             }
             if(NULL != device_id) {
-                g_callback_list.callback_node[g_callback_list.total_callbacks].device_id = malloc(strlen(device_id)+1);
+                g_callback_list.callback_node[g_callback_list.total_callbacks].device_id = (char *)malloc(strlen(device_id)+1);
                 if(NULL !=g_callback_list.callback_node[g_callback_list.total_callbacks].device_id) {
                     memset(g_callback_list.callback_node[g_callback_list.total_callbacks].device_id, 0, strlen(device_id)+1);
                     memcpy(g_callback_list.callback_node[g_callback_list.total_callbacks].device_id, device_id, strlen(device_id));
@@ -1023,13 +1023,13 @@ static void add_widget_subscibe_callback(topic_version_t version, char *topic, c
         } else {
             g_callback_list.widget_callback_node[g_callback_list.total_wcallbacks].pWidgetBase = pWidgetBase;
             g_callback_list.widget_callback_node[g_callback_list.total_wcallbacks].qos = qos;
-            g_callback_list.widget_callback_node[g_callback_list.total_wcallbacks].topic = malloc(strlen(topic)+1);
+            g_callback_list.widget_callback_node[g_callback_list.total_wcallbacks].topic = (char *)malloc(strlen(topic)+1);
             if(NULL !=g_callback_list.widget_callback_node[g_callback_list.total_wcallbacks].topic) {
                 memset(g_callback_list.widget_callback_node[g_callback_list.total_wcallbacks].topic, 0, strlen(topic)+1);
                 memcpy(g_callback_list.widget_callback_node[g_callback_list.total_wcallbacks].topic, topic, strlen(topic));
             }
             if(NULL != device_id) {
-                g_callback_list.widget_callback_node[g_callback_list.total_wcallbacks].device_id = malloc(strlen(device_id)+1);
+                g_callback_list.widget_callback_node[g_callback_list.total_wcallbacks].device_id = (char *)malloc(strlen(device_id)+1);
                 if(NULL !=g_callback_list.widget_callback_node[g_callback_list.total_wcallbacks].device_id) {
                     memset(g_callback_list.widget_callback_node[g_callback_list.total_wcallbacks].device_id, 0, strlen(device_id)+1);
                     memcpy(g_callback_list.widget_callback_node[g_callback_list.total_wcallbacks].device_id, device_id, strlen(device_id));

--- a/system/src/system_datapoint.cpp
+++ b/system/src/system_datapoint.cpp
@@ -36,7 +36,7 @@
 #ifdef SYSTEM_DATAPOINT_DEBUG
 #define SDATAPOINT_DEBUG(...)  do {DEBUG(__VA_ARGS__);}while(0)
 #define SDATAPOINT_DEBUG_D(...)  do {DEBUG_D(__VA_ARGS__);}while(0)
-static void debug_dump(const char* buf, int len)
+static void debug_dump(uint8_t *buf, uint16_t len)
 {
     int i = 0;
 
@@ -229,7 +229,7 @@ void intorobotDefineDatapointBinary(const uint16_t dpID, const dp_permission_t p
 
         // Create property structure
         property_conf_t *prop = new property_conf_t {dpID, DATA_TYPE_BINARY, permission, policy, (long)lapseTemp*1000, 0, false, RESULT_DATAPOINT_OLD};
-        prop->valueBinary.value = malloc(len);
+        prop->valueBinary.value = (uint8_t *)malloc(len);
         if(NULL != prop->valueBinary.value) {
             memcpy(prop->valueBinary.value, value, len);
             prop->valueBinary.len = len;
@@ -421,7 +421,7 @@ void intorobotWriteDatapointBinary(const uint16_t dpID, const uint8_t* value, co
             if(NULL != properties[i]->valueBinary.value) {
                 free(properties[i]->valueBinary.value);
             }
-            properties[i]->valueBinary.value = malloc(len);
+            properties[i]->valueBinary.value = (uint8_t *)malloc(len);
             if(NULL != properties[i]->valueBinary.value) {
                 memcpy(properties[i]->valueBinary.value, value, len);
                 properties[i]->valueBinary.len = len;
@@ -652,7 +652,7 @@ static uint16_t intorobotFormSingleDatapoint(int property_index, uint8_t* buffer
 }
 
 // type   0: 组织改变的数据点   1：组织全部的数据点
-static uint16_t intorobotFormAllDatapoint(char* buffer, uint16_t len, uint8_t type)
+static uint16_t intorobotFormAllDatapoint(uint8_t *buffer, uint16_t len, uint8_t type)
 {
     int32_t index = 0;
 
@@ -669,13 +669,13 @@ static uint16_t intorobotFormAllDatapoint(char* buffer, uint16_t len, uint8_t ty
         }
 
         if( type || ((!type) && properties[i]->change) )  {
-            index += intorobotFormSingleDatapoint(i, buffer+index, len);
+            index += intorobotFormSingleDatapoint(i, (uint8_t *)buffer+index, len);
         }
     }
     return index;
 }
 
-static _intorobotSendRawData(uint8_t *data, uint16_t dataLen)
+static void _intorobotSendRawData(uint8_t *data, uint16_t dataLen)
 {
     SDATAPOINT_DEBUG_D("send data:");
     SDATAPOINT_DEBUG_DUMP(data, dataLen);

--- a/system/src/system_task.cpp
+++ b/system/src/system_task.cpp
@@ -182,7 +182,7 @@ static bool _device_register(void)
     md5.add((uint8_t *)payload.c_str(), payload.length());
     md5.calculate();
     system_get_product_id(buffer, sizeof(buffer));
-    return intorobot_device_register(buffer, md5.toString().c_str());
+    return intorobot_device_register(buffer, (char *)md5.toString().c_str());
 }
 
 void preprocess_cloud_connection(void)
@@ -376,7 +376,7 @@ void system_process_loop(void)
  * @brief This should block for a certain number of milliseconds and also execute system_process_loop
  */
 #ifndef configNO_LORAWAN
-static void system_delay_pump(unsigned long ms, bool force_no_background_loop=false)
+static void system_delay_pump(unsigned long ms, bool force_no_background_loop)
 {
     HAL_Core_System_Yield();
     if (ms==0) return;
@@ -396,7 +396,7 @@ static void system_delay_pump(unsigned long ms, bool force_no_background_loop=fa
     }
 }
 #else
-static void system_delay_pump(unsigned long ms, bool force_no_background_loop=false)
+static void system_delay_pump(unsigned long ms, bool force_no_background_loop)
 {
     HAL_Core_System_Yield();
     if (ms==0) return;
@@ -442,7 +442,7 @@ static void system_delay_pump(unsigned long ms, bool force_no_background_loop=fa
  * On a non threaded platform, or when called from the application thread, then
  * run the background loop so that application events are processed.
  */
-void system_delay_ms(unsigned long ms, bool force_no_background_loop=false)
+void system_delay_ms(unsigned long ms, bool force_no_background_loop)
 {
     // if not threading, or we are the application thread, then implement delay
     // as a background message pump

--- a/system/src/system_test.cpp
+++ b/system/src/system_test.cpp
@@ -20,9 +20,9 @@
 #include "intorobot_config.h"
 #ifdef configSETUP_ENABLE
 
+#include "system_test.h"
 #include "ajson.h"
 #include "wiring.h"
-#include "system_test.h"
 #include "system_config.h"
 #include "platforms.h"
 #include "rtc_hal.h"

--- a/system/src/system_update.cpp
+++ b/system/src/system_update.cpp
@@ -260,14 +260,14 @@ size_t UpdaterClass::writeStream(Stream &data) {
     }
     while(remaining()) {
         if((_bufferLen + remaining()) <= UPDATE_SECTOR_SIZE) {
-            toRead = data.readBytes(_buffer + _bufferLen, remaining());
+            toRead = data.readBytes((char *)_buffer + _bufferLen, remaining());
         } else {
-            toRead = data.readBytes(_buffer + _bufferLen, (UPDATE_SECTOR_SIZE - _bufferLen));
+            toRead = data.readBytes((char *)_buffer + _bufferLen, (UPDATE_SECTOR_SIZE - _bufferLen));
         }
 
         if(toRead == 0) { //Timeout
             delay(100);
-            toRead = data.readBytes(_buffer + _bufferLen, (UPDATE_SECTOR_SIZE - _bufferLen));
+            toRead = data.readBytes((char *)_buffer + _bufferLen, (UPDATE_SECTOR_SIZE - _bufferLen));
             if(toRead == 0) { //Timeout
                 _error = UPDATE_ERROR_STREAM;
                 _currentAddress = (_startAddress + _size);

--- a/system/src/system_utilities.cpp
+++ b/system/src/system_utilities.cpp
@@ -119,7 +119,7 @@ int system_get_params_int(system_params_t params_type, int &value) {
 int system_set_params_int(system_params_t params_type, int value) {
     switch(params_type) {
         case SYSTEM_PARAMS_SECURITY_MODE:
-            HAL_PARAMS_Set_System_at_mode(value);
+            HAL_PARAMS_Set_System_at_mode((AT_MODE_FLAG_TypeDef)value);
             HAL_PARAMS_Save_Params();
             return 0;
             break;
@@ -145,10 +145,6 @@ uint16_t system_get_params_array(system_params_t params_type, char *buffer, uint
         case SYSTEM_PARAMS_PRODUCT_BOARD_NAME:
             return system_get_board_name(buffer, len);
             break;
-        case SYSTEM_PARAMS_SECURITY_MODE:
-            *buffer = HAL_PARAMS_Get_System_at_mode();
-            return 1;
-            break;
         default:
             break;
     }
@@ -162,11 +158,6 @@ int system_set_params_array(system_params_t params_type, char *buffer, uint16_t 
             break;
         case SYSTEM_PARAMS_PRODUCT_BOARD_NAME:
             return system_set_board_name(buffer);
-            break;
-        case SYSTEM_PARAMS_SECURITY_MODE:
-            HAL_PARAMS_Set_System_at_mode(*buffer);
-            HAL_PARAMS_Save_Params();
-            return 0;
             break;
         default:
             break;

--- a/wiring/inc/wiring_intorobot.h
+++ b/wiring/inc/wiring_intorobot.h
@@ -21,7 +21,7 @@
 #define WIRING_INTOROBOT_H_
 
 #include "intorobot_config.h"
-#include <stdio.h>
+//#include <stdio.h>
 #include "wiring_string.h"
 #include "system_cloud.h"
 #include "system_lorawan.h"

--- a/wiring/inc/wiring_product.h
+++ b/wiring/inc/wiring_product.h
@@ -54,10 +54,10 @@ struct __ApplicationProductType {
     }
 };
 
-#define PRODUCT_ID(x)                __ApplicationProductID __appProductID(stringify(x));
-#define PRODUCT_SECRET(x)            __ApplicationProductSecret __appProductSecret(stringify(x));
-#define PRODUCT_SOFTWARE_VERSION(x)  __ApplicationProductSoftwareVersion __appProductSoftwareVersion(stringify(x));
-#define PRODUCT_HARDWARE_VERSION(x)  __ApplicationProductHardwareVersion __appProductHardwareVersion(stringify(x));
+#define PRODUCT_ID(x)                __ApplicationProductID __appProductID((char *)stringify(x));
+#define PRODUCT_SECRET(x)            __ApplicationProductSecret __appProductSecret((char *)stringify(x));
+#define PRODUCT_SOFTWARE_VERSION(x)  __ApplicationProductSoftwareVersion __appProductSoftwareVersion((char *)stringify(x));
+#define PRODUCT_HARDWARE_VERSION(x)  __ApplicationProductHardwareVersion __appProductHardwareVersion((char *)stringify(x));
 #define PRODUCT_VERSION(x)           PRODUCT_SOFTWARE_VERSION(x);
 #define PRODUCT_TYPE(x)              __ApplicationProductType __appProductType(x);
 

--- a/wiring/inc/wiring_system.h
+++ b/wiring/inc/wiring_system.h
@@ -155,7 +155,7 @@ public:
 
     uint16_t get(system_params_t params_type, const void *data, uint16_t length)
     {
-        return system_get_params_array(params_type, (uint8_t *)data, length);
+        return system_get_params_array(params_type, (char *)data, length);
     }
 
     bool set(system_params_t params_type, int value)
@@ -175,7 +175,7 @@ public:
 
     bool set(system_params_t params_type, const void *data, uint16_t length)
     {
-        return system_set_params_array(params_type, (uint8_t *)data, length) >= 0;
+        return system_set_params_array(params_type, (char *)data, length) >= 0;
     }
 
     inline bool featureEnabled(system_feature_t feature)

--- a/wiring/src/wiring_httpclient.cpp
+++ b/wiring/src/wiring_httpclient.cpp
@@ -415,7 +415,7 @@ int HTTPClient::sendRequest(const char * type, Stream * stream, size_t size)
                 }
 
                 // read data
-                int bytesRead = stream->readBytes(buff, readBytes);
+                int bytesRead = stream->readBytes((char *)buff, readBytes);
 
                 // write it to Stream
                 int bytesWrite = _tcp->write((const uint8_t *) buff, bytesRead);
@@ -594,7 +594,7 @@ int HTTPClient::writeToStream(Stream * stream)
 
             // read trailing \r\n at the end of the chunk
             char buf[2];
-            auto trailing_seq_len = _tcp->readBytes((uint8_t*)buf, 2);
+            auto trailing_seq_len = _tcp->readBytes((char *)buf, 2);
             if (trailing_seq_len != 2 || buf[0] != '\r' || buf[1] != '\n') {
                 return returnError(HTTPC_ERROR_READ_TIMEOUT);
             }
@@ -976,7 +976,7 @@ int HTTPClient::writeToStreamDataBlock(Stream * stream, int size)
                 }
 
                 // read data
-                int bytesRead = _tcp->readBytes(buff, readBytes);
+                int bytesRead = _tcp->readBytes((char *)buff, readBytes);
 
                 // write it to Stream
                 int bytesWrite = stream->write(buff, bytesRead);


### PR DESCRIPTION
1. 清除警告信息
2. 编译处理的framework在macos上loragateway项目无法启动。原因:boot/system参数结构体__attribute__((packed))参数。因为参数全局变量地址可能不是4字节对齐。导致flash read操作死机。

---

Doneness(完成点):
- [ ] Problem and Solution clearly stated (问题和解决方案描述清楚)
- [ ] Code peer reviewed(代码检查完毕)
- [ ] API tests compiled(API接口测试完毕)
- [ ] Add documentation(添加相关文档)
- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)(合并后往CHANGELOG.md添加注释，包括文档链接和issues)
