### PR TITLE
修正lorawan休眠唤醒后串口无法接收数据问题

### DIFF
--- a/hal/src/ant/usart_hal.c
+++ b/hal/src/ant/usart_hal.c
@@ -241,7 +241,7 @@ void HAL_USART_End(HAL_USART_Serial serial)
     HAL_NVIC_DisableIRQ(usartMap[serial]->usart_int_n);
 
     // clear any received data
-    sdkReleaseQueue(usartMap[serial]->usart_rx_queue);
+    /* sdkReleaseQueue(usartMap[serial]->usart_rx_queue);//休眠唤醒后没有申请内存导致无法接收 注释此句 */
 
     // Undo any pin re-mapping done for this USART
     // ...

--- a/hal/src/l6/usart_hal.c
+++ b/hal/src/l6/usart_hal.c
@@ -241,7 +241,7 @@ void HAL_USART_End(HAL_USART_Serial serial)
     HAL_NVIC_DisableIRQ(usartMap[serial]->usart_int_n);
 
     // clear any received data
-    sdkReleaseQueue(usartMap[serial]->usart_rx_queue);
+    /* sdkReleaseQueue(usartMap[serial]->usart_rx_queue); //休眠唤醒后没有申请内存导致无法接收 注释此句 */
 
     // Undo any pin re-mapping done for this USART
     // ...


### PR DESCRIPTION
1.lorawan休眠唤醒后串口无法接收数据，原因是在Serial.end()将申请的数据缓冲区释放了。
