### PR TITLE
解决ant GPIO口操作异常

### DIFF
--- a/hal/src/ant/pinmap_hal.c
+++ b/hal/src/ant/pinmap_hal.c
@@ -44,7 +44,7 @@
 
 /* Private typedef -----------------------------------------------------------*/
 
-STM32_Pin_Info __PIN_MAP[TOTAL_PINS] =
+const STM32_Pin_Info __PIN_MAP[TOTAL_PINS] =
 {
 /*
  * gpio_peripheral (GPIOA, GPIOB, GPIOC or GPIOD)

--- a/hal/src/anytest/pinmap_hal.c
+++ b/hal/src/anytest/pinmap_hal.c
@@ -44,7 +44,7 @@
 
 /* Private typedef -----------------------------------------------------------*/
 
-STM32_Pin_Info __PIN_MAP[TOTAL_PINS] =
+const STM32_Pin_Info __PIN_MAP[TOTAL_PINS] =
 {
     /*
     * gpio_peripheral (GPIOA or GPIOB or GPIOC or GPIOD)

--- a/hal/src/atom/pinmap_hal.c
+++ b/hal/src/atom/pinmap_hal.c
@@ -44,7 +44,7 @@
 
 /* Private typedef -----------------------------------------------------------*/
 
-STM32_Pin_Info __PIN_MAP[TOTAL_PINS] =
+const STM32_Pin_Info __PIN_MAP[TOTAL_PINS] =
 {
     /*
     * gpio_peripheral (GPIOA or GPIOB or GPIOC or GPIOD)

--- a/hal/src/fig/pinmap_hal.c
+++ b/hal/src/fig/pinmap_hal.c
@@ -92,7 +92,7 @@
 
 /* Private typedef -----------------------------------------------------------*/
 
-ESP32_Pin_Info __PIN_MAP[TOTAL_PINS] =
+const ESP32_Pin_Info __PIN_MAP[TOTAL_PINS] =
 {
 /*
  * gpio_pin (0-16)

--- a/hal/src/fox/pinmap_hal.c
+++ b/hal/src/fox/pinmap_hal.c
@@ -44,7 +44,7 @@
 
 /* Private typedef -----------------------------------------------------------*/
 
-STM32_Pin_Info __PIN_MAP[TOTAL_PINS] =
+const STM32_Pin_Info __PIN_MAP[TOTAL_PINS] =
 {
 /*
  * gpio_peripheral (GPIOA, GPIOB, GPIOC or GPIOD)

--- a/hal/src/gl2000/pinmap_hal.c
+++ b/hal/src/gl2000/pinmap_hal.c
@@ -44,7 +44,7 @@
 
 /* Private typedef -----------------------------------------------------------*/
 
-STM32_Pin_Info __PIN_MAP[TOTAL_PINS] =
+const STM32_Pin_Info __PIN_MAP[TOTAL_PINS] =
 {
 /*
  * gpio_peripheral (GPIOA, GPIOB, GPIOC or GPIOD)

--- a/hal/src/gl2100/pinmap_hal.c
+++ b/hal/src/gl2100/pinmap_hal.c
@@ -44,7 +44,7 @@
 
 /* Private typedef -----------------------------------------------------------*/
 
-STM32_Pin_Info __PIN_MAP[TOTAL_PINS] =
+const STM32_Pin_Info __PIN_MAP[TOTAL_PINS] =
 {
 /*
  * gpio_peripheral (GPIOA, GPIOB, GPIOC or GPIOD)

--- a/hal/src/l6/pinmap_hal.c
+++ b/hal/src/l6/pinmap_hal.c
@@ -44,7 +44,7 @@
 
 /* Private typedef -----------------------------------------------------------*/
 
-STM32_Pin_Info __PIN_MAP[TOTAL_PINS] =
+const STM32_Pin_Info __PIN_MAP[TOTAL_PINS] =
 {
 /*
  * gpio_peripheral (GPIOA, GPIOB, GPIOC or GPIOD)

--- a/hal/src/neutron/pinmap_hal.c
+++ b/hal/src/neutron/pinmap_hal.c
@@ -44,7 +44,7 @@
 
 /* Private typedef -----------------------------------------------------------*/
 
-STM32_Pin_Info __PIN_MAP[TOTAL_PINS] =
+const STM32_Pin_Info __PIN_MAP[TOTAL_PINS] =
 {
 /*
  * gpio_peripheral (GPIOA, GPIOB, GPIOC or GPIOD)

--- a/hal/src/nut/pinmap_hal.c
+++ b/hal/src/nut/pinmap_hal.c
@@ -66,7 +66,7 @@
 
 /* Private typedef -----------------------------------------------------------*/
 
-EESP8266_Pin_Info __PIN_MAP[TOTAL_PINS] =
+const EESP8266_Pin_Info __PIN_MAP[TOTAL_PINS] =
 {
 /*
  * gpio_pin (0-16)

--- a/hal/src/w323/pinmap_hal.c
+++ b/hal/src/w323/pinmap_hal.c
@@ -110,7 +110,7 @@
 
 
 /* Private typedef -----------------------------------------------------------*/
-ESP32_Pin_Info __PIN_MAP[TOTAL_PINS] =
+const ESP32_Pin_Info __PIN_MAP[TOTAL_PINS] =
 {
 /*
  * gpio_pin (0-16)

--- a/hal/src/w67/pinmap_hal.c
+++ b/hal/src/w67/pinmap_hal.c
@@ -66,7 +66,7 @@
 
 /* Private typedef -----------------------------------------------------------*/
 
-EESP8266_Pin_Info __PIN_MAP[TOTAL_PINS] =
+const EESP8266_Pin_Info __PIN_MAP[TOTAL_PINS] =
 {
 /*
  * gpio_pin (0-16)


### PR DESCRIPTION
1. pinmap_hal.c PIN_MAP 用const修饰，编译到flash中，否则Ant 这部分内存会被篡改。

---

Doneness(完成点):
- [ ] Problem and Solution clearly stated (问题和解决方案描述清楚)
- [ ] Code peer reviewed(代码检查完毕)
- [ ] API tests compiled(API接口测试完毕)
- [ ] Add documentation(添加相关文档)
- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)(合并后往CHANGELOG.md添加注释，包括文档链接和issues)
