### PR TITLE
修正ant PinMap读取错误问题

### DIFF
--- a/hal/src/stm32l1xx-share/pinmap_impl.h
+++ b/hal/src/stm32l1xx-share/pinmap_impl.h
@@ -31,7 +31,7 @@ typedef struct STM32_Pin_Info {
     GPIO_TypeDef* gpio_peripheral;
     pin_t gpio_pin;
     uint8_t gpio_pin_source;
-    uint8_t adc_channel;
+    uint32_t adc_channel;
     uint8_t dac_channel;
     TIM_TypeDef* timer_peripheral;
     uint16_t timer_ch;


### PR DESCRIPTION
修正ant PinMap 第30读取错误，将ad_channcl改为uint32_t 根本原因后续再查
