### PR TITLE
1.lorawan修改RX1延迟时间设置时 RX2需在RX1基础上加上1s的延迟

### DIFF
--- a/communication/lorawan/mac/inc/LoRaMac-definitions.h
+++ b/communication/lorawan/mac/inc/LoRaMac-definitions.h
@@ -32,17 +32,6 @@ extern "C" {
 
 #if defined( USE_BAND_433 )
 
-#define LORAMAC_TX_FIXED_FREQUENCY    433575000
-#define LORAMAC_TX_FIXED_DATARATE     DR_3
-
-#define LORAMAC_RX1_FIXED_FREQUENCY    433575000
-#define LORAMAC_RX1_FIXED_DATARATE     DR_3
-
-#define LORAMAC_RX2_FIXED_FREQUENCY    434665000
-#define LORAMAC_RX2_FIXED_DATARATE     DR_3
-
-#define LORAMAC_FIXED_BANDWIDTH    0
-
 /*!
  * LoRaMac maximum number of channels
  */
@@ -71,8 +60,7 @@ extern "C" {
 /*!
  * Default datarate used by the node
  */
-// #define LORAMAC_DEFAULT_DATARATE                    DR_0
-#define LORAMAC_DEFAULT_DATARATE                    DR_3
+#define LORAMAC_DEFAULT_DATARATE                    DR_0
 
 /*!
  * Minimal Rx1 receive datarate offset
@@ -149,10 +137,6 @@ extern "C" {
 #define LC1                { 433175000, { ( ( DR_5 << 4 ) | DR_0 ) }, 0 }
 #define LC2                { 433375000, { ( ( DR_5 << 4 ) | DR_0 ) }, 0 }
 #define LC3                { 433575000, { ( ( DR_5 << 4 ) | DR_0 ) }, 0 }
-//先固定频率进行调试
-// #define LC1                { 433575000, { ( ( DR_5 << 4 ) | DR_0 ) }, 0 }
-// #define LC2                { 433575000, { ( ( DR_5 << 4 ) | DR_0 ) }, 0 }
-// #define LC3                { 433575000, { ( ( DR_5 << 4 ) | DR_0 ) }, 0 }
 
 /*!
  * LoRaMac channels which are allowed for the join procedure

--- a/communication/lorawan/mac/src/LoRaMac.c
+++ b/communication/lorawan/mac/src/LoRaMac.c
@@ -3354,7 +3354,6 @@ LoRaMacStatus_t SendFrameOnChannel( ChannelParams_t channel )
     McpsConfirm.UpLinkFrequency = channel.Frequency;
 
     Radio.SetChannel( channel.Frequency );
-    /* LORAMAC_DEBUG("loramac tx frequency = %d\r\n",channel.Frequency); */
 
 #if defined( USE_BAND_433 ) || defined( USE_BAND_780 ) || defined( USE_BAND_868 )
     if( LoRaMacParams.ChannelsDatarate == DR_7 )
@@ -3372,8 +3371,9 @@ LoRaMacStatus_t SendFrameOnChannel( ChannelParams_t channel )
     }
     else
     { // Normal LoRa channel
-        #if  0
+        #if 1
         LORAMAC_DEBUG("loramac normal channel send\r\n");
+        LORAMAC_DEBUG("loramac tx frequency = %d\r\n",channel.Frequency);
         LORAMAC_DEBUG("tx power=%d\r\n",txPower);
         LORAMAC_DEBUG("datarate=%d\r\n",datarate);
         #endif
@@ -4053,6 +4053,7 @@ LoRaMacStatus_t LoRaMacMibSetRequestConfirm( MibRequestConfirm_t *mibSet )
         case MIB_RECEIVE_DELAY_1:
         {
             LoRaMacParams.ReceiveDelay1 = mibSet->Param.ReceiveDelay1;
+            LoRaMacParams.ReceiveDelay2 = LoRaMacParams.ReceiveDelay1+1e3;
             break;
         }
         case MIB_RECEIVE_DELAY_2:

--- a/wiring/src/wiring_lorawan.cpp
+++ b/wiring/src/wiring_lorawan.cpp
@@ -404,16 +404,19 @@ void LoRaWanClass::setChannelStatus(uint8_t channel, bool enable)
     uint16_t channelMask = 0;
     mibReq.Type = MIB_CHANNELS_MASK;
     if(LoRaMacMibGetRequestConfirm( &mibReq ) != LORAMAC_STATUS_OK){
+        WLORAWAN_DEBUG("get channelMask fail\r\n");
         return;
     }
 
     channelMask = *mibReq.Param.ChannelsMask;
+    WLORAWAN_DEBUG("channelMask1=%d\r\n",channelMask);
     if(enable){
         channelMask = channelMask | (1<<channel);
     }else{
         channelMask = channelMask & (~(1<<channel));
     }
 
+    WLORAWAN_DEBUG("channelMask2=%d\r\n",channelMask);
     mibReq.Type = MIB_CHANNELS_DEFAULT_MASK;
     mibReq.Param.ChannelsDefaultMask = &channelMask;
     LoRaMacMibSetRequestConfirm( &mibReq );


### PR DESCRIPTION
1.lorawan修改RX1延迟时间设置时 RX2需在RX1基础上加上1s的延迟
2.去掉部分无用宏定义
3.将RX2的默认频率和扩频因子设为434665M和12

