### PR TITLE
lorawan修正发射功率获取错误和发射功率倍率设置

### DIFF
--- a/communication/lorawan/mac/src/region/RegionCommon.c
+++ b/communication/lorawan/mac/src/region/RegionCommon.c
@@ -313,7 +313,7 @@ int8_t RegionCommonComputeTxPower( int8_t txPowerIndex, float maxEirp, float ant
 {
     int8_t phyTxPower = 0;
 
-    phyTxPower = ( int8_t )floor( ( maxEirp - ( txPowerIndex * 2U ) ) - antennaGain );
+    phyTxPower = ( int8_t )floor( ( maxEirp - ( txPowerIndex * 3U ) ) - antennaGain );
 
     return phyTxPower;
 }

--- a/wiring/src/wiring_lorawan.cpp
+++ b/wiring/src/wiring_lorawan.cpp
@@ -297,7 +297,7 @@ uint8_t LoRaWanClass::getTxPower(void)
 {
     MibRequestConfirm_t mibReq;
     mibReq.Type = MIB_CHANNELS_TX_POWER;
-    if(LoRaMacMibSetRequestConfirm( &mibReq ) != LORAMAC_STATUS_OK){
+    if(LoRaMacMibGetRequestConfirm( &mibReq ) != LORAMAC_STATUS_OK){
         return;
     }
     _txPower = mibReq.Param.ChannelsTxPower;


### PR DESCRIPTION
1.lorawan将发射功率修改以3的倍率递减，修改后的发射功率为20/17/14/11/7/4db
2.修正lorawan获取发射功率错误问题，原因为接口函数调用错误
