### PR TITLE
esp32 添加tcp server功能

### DIFF
--- a/system/src/system_network_internal.h
+++ b/system/src/system_network_internal.h
@@ -211,12 +211,14 @@ public:
     bool ready() override
     {
         drive_now();
+        update_config(false);
         return (INTOROBOT_WLAN_STARTED && WLAN_DHCP);
     }
 
     bool connecting() override
     {
         drive_now();
+        update_config(false);
         return (INTOROBOT_WLAN_STARTED && WLAN_CONNECTING);
     }
 
@@ -293,6 +295,7 @@ public:
             SNETWORK_DEBUG("CLR_WLAN_WD 1, DHCP success\r\n");
             CLR_WLAN_WD();
             WLAN_DHCP = 1;
+            update_config(true); //去掉，否则wifiJoinAp调用时会触发DHCP事件，导致AT指令任务忙等现象。neutron。
         } else {
             config_clear();
             WLAN_DHCP = 0;


### PR DESCRIPTION
1. esp32 添加tcp server功能
2. 修正while(!WiFi.ready()) 后直接调用WiFi.localIP()无法获取ip地址。

---

Doneness(完成点):
- [ ] Problem and Solution clearly stated (问题和解决方案描述清楚)
- [ ] Code peer reviewed(代码检查完毕)
- [ ] API tests compiled(API接口测试完毕)
- [ ] Add documentation(添加相关文档)
- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)(合并后往CHANGELOG.md添加注释，包括文档链接和issues)
