### PR TITLE
修正用户控制三色灯后，进入配置模式三色灯指示不正常

### DIFF
--- a/system/src/main.cpp
+++ b/system/src/main.cpp
@@ -100,8 +100,8 @@ extern "C" void HAL_SysTick_Handler(void)
     if(BUTTON_press_time) {
         if( BUTTON_press_time > TIMING_MODE_FACTORY_RESET ) {
             if(BUTTON_Mode!=BUTTON_MODE_FAC) {
-                BUTTON_Mode=BUTTON_MODE_FAC;       //恢复出厂设置
-                HAL_UI_RGB_Color(RGB_COLOR_YELLOW);//黄灯打开
+                BUTTON_Mode=BUTTON_MODE_FAC;          //恢复出厂设置
+                HAL_UI_RGB_Color(RGB_COLOR_YELLOW);   //黄灯打开
             }
         }
         else if( BUTTON_press_time > TIMING_MODE_CONFIG_IMLINK_SERIAL ) {

--- a/system/src/system_config.cpp
+++ b/system/src/system_config.cpp
@@ -43,6 +43,7 @@
 #include "system_test.h"
 #include "system_utilities.h"
 #include "system_event.h"
+#include "wiring_rgb.h"
 
 /*debug switch*/
 #define SYSTEM_CONFIG_DEBUG
@@ -1031,6 +1032,8 @@ system_config_type_t get_system_config_type(void)
 void system_config_initial(void)
 {
     SCONFIG_DEBUG("system config initial\r\n");
+    RGB.control(false);  //进入配置模式由系统接管
+    system_rgb_blink(RGB_COLOR_RED, 1000);
     HAL_Core_Enter_Config();
     switch(get_system_config_type()) {
         case SYSTEM_CONFIG_TYPE_IMLINK_SERIAL:   //进入串口配置模式
@@ -1224,7 +1227,6 @@ void manage_system_config(void)
 {
     if(System.featureEnabled(SYSTEM_FEATURE_AUTO_CONFIG_PROCESS_ENABLED)) {
         if(SYSTEM_CONFIG_TYPE_NONE != get_system_config_type()) {
-            system_rgb_blink(RGB_COLOR_RED, 1000);
             while(1) {
                 if(system_config_process()) {
                     break;


### PR DESCRIPTION
1. 修正用户控制三色灯后，进入配置模式三色灯指示不正常。(#188)

---

Doneness(完成点):
- [ ] Problem and Solution clearly stated (问题和解决方案描述清楚)
- [ ] Code peer reviewed(代码检查完毕)
- [ ] API tests compiled(API接口测试完毕)
- [ ] Add documentation(添加相关文档)
- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)(合并后往CHANGELOG.md添加注释，包括文档链接和issues)
